### PR TITLE
fix(DEVOPS-7808): ensure renovate configured in all repos using public actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>Lendable/renovate-config"
+  ]
+}


### PR DESCRIPTION
# [DEVOPS-7808]
## Changes

due to incident https://lendable.slack.com/archives/C08HNKQ4F7G

We are moving all GitHub Action references to git sha1 rather than tags.

We will use renovote to achive this and therefore need to enable it in all repositories.

We also need to ensure that all renovate config extends from the [lendable base config](https://github.com/Lendable/renovate-config/blob/main/default.json)

This is so that we can control the delay before referencing the latest sha1 commits to give the comunity some time to pick up on any malitious commits.


[DEVOPS-7808]: https://lendable-uk.atlassian.net/browse/DEVOPS-7808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ